### PR TITLE
Add the `--skip-ssl` option to mysql queries

### DIFF
--- a/R/trackplot.R
+++ b/R/trackplot.R
@@ -1821,7 +1821,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   }
   
   cmd = paste0(
-    "mysql --user genome --host genome-mysql.soe.ucsc.edu -NAD ",
+    "mysql --user genome --host genome-mysql.soe.ucsc.edu --skip-ssl -NAD ",
     refBuild,
     " -e 'select chrom, chromStart, chromEnd, name, gieStain from ",  tblName, " WHERE chrom =\"",
     chr,
@@ -1897,7 +1897,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   
   .check_mysql()
   
-  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu -NAD ",  refBuild,  " -e 'select chrom, chromStart, chromEnd, name from ", tbl, " WHERE chrom =\"", tar_chr, "\"'")
+  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu --skip-ssl -NAD ",  refBuild,  " -e 'select chrom, chromStart, chromEnd, name from ", tbl, " WHERE chrom =\"", tar_chr, "\"'")
   message(paste0("Extracting chromHMM from UCSC:\n", "    chromosome: ", tar_chr, "\n", "    build: ", refBuild, "\n    query: ", cmd))
   #system(command = cmd)
   ucsc = data.table::fread(cmd = cmd)
@@ -1921,7 +1921,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   .check_mysql()
   op_file = tempfile(pattern = "ucsc", fileext = ".tsv")
   
-  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2, exonStarts, exonEnds from refGene WHERE name2 =\"", genesymbol, "\"'")
+  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu --skip-ssl -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2, exonStarts, exonEnds from refGene WHERE name2 =\"", genesymbol, "\"'")
   message(paste0("Extracting gene models from UCSC:\n", "    Gene: ", genesymbol, "\n", "    build: ", refBuild, "\n    query: ", cmd))
   
   ucsc = data.table::fread(cmd = cmd, sep = "\t")
@@ -1946,7 +1946,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
     tar_chr = chr
   }
   
-  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2, exonStarts, exonEnds from refGene WHERE chrom =\"", tar_chr, "\"'")
+  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu --skip-ssl -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2, exonStarts, exonEnds from refGene WHERE chrom =\"", tar_chr, "\"'")
   message(paste0("Extracting gene models from UCSC:\n", "    chromosome: ", tar_chr, "\n", "    build: ", refBuild, "\n    query: ", cmd))
   #system(command = cmd)
   ucsc = data.table::fread(cmd = cmd)
@@ -2159,7 +2159,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   
   temp_op_bed = tempfile(pattern = "profileplot_ucsc", tmpdir = op_dir, fileext = ".bed")
   
-  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2 from refGene'")
+  cmd = paste0("mysql --user genome --host genome-mysql.soe.ucsc.edu --skip-ssl -NAD ",  refBuild,  " -e 'select chrom, txStart, txEnd, strand, name, name2 from refGene'")
   message(paste0("Extracting gene models from UCSC:\n", "    build: ", refBuild, "\n    query: ", cmd))
   #system(command = cmd)
   ucsc = data.table::fread(cmd = cmd)

--- a/R/trackplot.R
+++ b/R/trackplot.R
@@ -1701,7 +1701,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   lo_h_ord[lord]
 }
 
-.gen_windows = function(chr = NA, start, end, window_size = 50, op_dir = getwd()){
+.gen_windows = function(chr = NA, start, end, window_size = 50, op_dir = getwd(), verbose = FALSE){
   #chr = "chr19"; start = 15348301; end = 15391262; window_size = 50; op_dir = getwd()
   message(paste0("Generating windows ", "[", window_size, " bp window size]"))
   
@@ -1714,7 +1714,9 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   window_dat$chr = chr
   window_dat = window_dat[, .(chr, start, end)]
   
-  print(window_dat)
+  if(verbose) {
+      print(window_dat)
+  }
   
   op_dir = paste0(op_dir, "/")
   
@@ -1813,7 +1815,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
   }
 }
 
-.extract_cytoband = function(chr = NULL, refBuild = "hg19", tblName = "cytoBand"){
+.extract_cytoband = function(chr = NULL, refBuild = "hg19", tblName = "cytoBand", verbose = FALSE){
   
   if(!grepl(pattern = "^chr", x = chr)){
     message("Adding chr prefix to target chromosome for UCSC query..")
@@ -1827,8 +1829,9 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
     chr,
     "\"'"
   )
-  message(paste0("Extracting cytobands from UCSC:\n", "    chromosome: ", chr, "\n", "    build: ", refBuild, "\n    query: ", cmd))
-  
+  if(verbose){
+    message(paste0("Extracting cytobands from UCSC:\n", "    chromosome: ", chr, "\n", "    build: ", refBuild, "\n    query: ", cmd))
+  }
   cyto = data.table::fread(cmd = cmd, colClasses = c("character", "numeric", "numeric", "character", "character"))
   colnames(cyto) = c("chr", "start", "end", "band", "stain")
   data.table::setkey(x = cyto, chr, start, end)
@@ -2035,7 +2038,7 @@ summarize_homer_annots = function(anno, sample_names = NULL, legend_font_size = 
 }
 
 .collapse_tx = function(exon_tbls){
-  message("Collapsing transcripts..")
+  #message("Collapsing transcripts..")
   tx_tbl = lapply(exon_tbls, function(x){
     xdt = data.table::data.table(start = x[[1]], end = x[[2]])
     xdt$tx = attr(x = x, which = "tx")


### PR DESCRIPTION
Without the option in MySQL queries, `track_extract()` will throw error about `data.table::fread()` falsely reporting full tempdir, while system log will show up an entry like:

```
ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
```

at the same time, causing all MySQL queries to UCSC server fail.